### PR TITLE
Fix tests to run at CircleCI

### DIFF
--- a/applications/users/migrations/0001_initial.py
+++ b/applications/users/migrations/0001_initial.py
@@ -27,8 +27,6 @@ class Migration(migrations.Migration):
                 ('is_superuser', models.BooleanField(default=False)),
                 ('is_active', models.BooleanField(default=True)),
                 ('date_joined', models.DateTimeField(default=django.utils.timezone.now)),
-                ('groups', models.ManyToManyField(blank=True, help_text='The groups this user belongs to. A user will get all permissions granted to each of their groups.', related_name='user_set', related_query_name='user', to='auth.Group', verbose_name='groups')),
-                ('user_permissions', models.ManyToManyField(blank=True, help_text='Specific permissions for this user.', related_name='user_set', related_query_name='user', to='auth.Permission', verbose_name='user permissions')),
             ],
             options={
                 'abstract': False,

--- a/applications/users/tests/test_user_log_in.py
+++ b/applications/users/tests/test_user_log_in.py
@@ -7,13 +7,14 @@ from .factories import UserFactory
 
 
 class ConfirmedUserLogInTests(APITestCase):
-    url = reverse('rest_login')
     fake = Faker()
 
     def call_log_in(self):
         return self.client.post(self.url, self.params)
 
     def setUp(self):
+        self.url = reverse('rest_login')
+
         self.password = self.fake.password(length=8)
         self.user = UserFactory(password=self.password, confirmed=True)
         self.params = {'email': self.user.email, 'password': self.password}
@@ -44,13 +45,14 @@ class ConfirmedUserLogInTests(APITestCase):
 
 
 class UnconfirmedUserLogInTests(APITestCase):
-    url = reverse('rest_login')
     fake = Faker()
 
     def call_log_in(self):
         return self.client.post(self.url, self.params)
 
     def setUp(self):
+        self.url = reverse('rest_login')
+
         self.password = self.fake.password(length=8)
         self.user = UserFactory(password=self.password)
         self.params = {'email': self.user.email, 'password': self.password}

--- a/applications/users/tests/test_user_log_in.py
+++ b/applications/users/tests/test_user_log_in.py
@@ -9,12 +9,14 @@ from .factories import UserFactory
 class ConfirmedUserLogInTests(APITestCase):
     fake = Faker()
 
+    @classmethod
+    def setUpTestData(cls):
+        cls.url = reverse('rest_login')
+
     def call_log_in(self):
         return self.client.post(self.url, self.params)
 
     def setUp(self):
-        self.url = reverse('rest_login')
-
         self.password = self.fake.password(length=8)
         self.user = UserFactory(password=self.password, confirmed=True)
         self.params = {'email': self.user.email, 'password': self.password}
@@ -47,12 +49,14 @@ class ConfirmedUserLogInTests(APITestCase):
 class UnconfirmedUserLogInTests(APITestCase):
     fake = Faker()
 
+    @classmethod
+    def setUpTestData(cls):
+        cls.url = reverse('rest_login')
+
     def call_log_in(self):
         return self.client.post(self.url, self.params)
 
     def setUp(self):
-        self.url = reverse('rest_login')
-
         self.password = self.fake.password(length=8)
         self.user = UserFactory(password=self.password)
         self.params = {'email': self.user.email, 'password': self.password}

--- a/applications/users/tests/test_user_registration.py
+++ b/applications/users/tests/test_user_registration.py
@@ -11,14 +11,15 @@ from applications.users.models import User
 class UserRegistrationTests(APITestCase):
     format = 'json'
 
+    @classmethod
+    def setUpTestData(cls):
+        cls.url = reverse('rest_register')
+
     @staticmethod
     def build_params():
         params = factory.build(dict, FACTORY_CLASS=BaseUserFactory)
         params['password1'] = params['password2'] = params['password']
         return params
-
-    def setUp(self):
-        self.url = reverse('rest_register')
 
     def test_all_params_right_respond_success(self):
         params = self.build_params()

--- a/applications/users/tests/test_user_registration.py
+++ b/applications/users/tests/test_user_registration.py
@@ -9,7 +9,6 @@ from applications.users.models import User
 
 
 class UserRegistrationTests(APITestCase):
-    url = reverse('rest_register')
     format = 'json'
 
     @staticmethod
@@ -17,6 +16,9 @@ class UserRegistrationTests(APITestCase):
         params = factory.build(dict, FACTORY_CLASS=BaseUserFactory)
         params['password1'] = params['password2'] = params['password']
         return params
+
+    def setUp(self):
+        self.url = reverse('rest_register')
 
     def test_all_params_right_respond_success(self):
         params = self.build_params()


### PR DESCRIPTION
## Fix tests to run at CircleCI

#### Description

* Use `reverse` at the test setups
* Fix duplicate added fields in migrations