### PR TITLE
Notification service

### DIFF
--- a/.circleci/ci.env
+++ b/.circleci/ci.env
@@ -6,3 +6,5 @@ DB_PASSWORD=
 DB_HOST=127.0.0.1
 DB_PORT=5432
 APP_SITE=http://localhost:8000/
+ONESIGNAL_APP_ID=fake-onesignal-api-id
+ONESIGNAL_API_KEY=fake-onesignal-api-key-fake-onesignal-api-key

--- a/applications/notifications/services.py
+++ b/applications/notifications/services.py
@@ -1,0 +1,43 @@
+from django.db import transaction
+import environ
+from onesignal_sdk.client import Client as OneSignalClient
+
+from .models import Notification
+
+env = environ.Env()
+
+
+class NotificationSender(object):
+    client = OneSignalClient(app_id=env('ONESIGNAL_APP_ID'), rest_api_key=env('ONESIGNAL_API_KEY'))
+
+    def send_notification(self, emails, data, message):
+        body = self._body(emails, data, message)
+        self.client.send_notification(body)
+
+    def _body(self, emails, data, message):
+        return {
+            'filters': self._create_filter_by_emails(emails),
+            'data': data,
+            'contents': {'en': message},
+        }
+
+    def _create_filter_by_emails(self, emails):
+        email_list = emails if type(emails) is list else [emails]
+
+        def email_filter(email):
+            return {'field': 'tag', 'key': 'email', 'relation': '=', 'value': email}
+
+        def filter_option(i):
+            return email_filter(email_list[int(i/2)]) if i % 2 == 0 else {'operator': 'OR'}
+
+        return [filter_option(i) for i in range(len(email_list*2) - 1)]
+
+
+class NotificationCreator(object):
+    sender = NotificationSender()
+
+    @transaction.atomic
+    def create(self, user, data, title, message):
+        Notification.objects.create(user=user, title=title, message=message)
+
+        self.sender.send_notification(user.email, data, message)

--- a/applications/notifications/services.py
+++ b/applications/notifications/services.py
@@ -24,13 +24,13 @@ class NotificationSender(object):
     def _create_filter_by_emails(self, emails):
         email_list = emails if type(emails) is list else [emails]
 
-        def email_filter(email):
-            return {'field': 'tag', 'key': 'email', 'relation': '=', 'value': email}
+        return [self._filter_option(email_list, i) for i in range(len(email_list*2) - 1)]
 
-        def filter_option(i):
-            return email_filter(email_list[int(i/2)]) if i % 2 == 0 else {'operator': 'OR'}
+    def _filter_option(self, options, index):
+        return self._email_filter(options[int(index/2)]) if index % 2 == 0 else {'operator': 'OR'}
 
-        return [filter_option(i) for i in range(len(email_list*2) - 1)]
+    def _email_filter(self, email):
+        return {'field': 'tag', 'key': 'email', 'relation': '=', 'value': email}
 
 
 class NotificationCreator(object):

--- a/applications/notifications/services.py
+++ b/applications/notifications/services.py
@@ -8,7 +8,10 @@ env = environ.Env()
 
 
 class NotificationSender(object):
-    client = OneSignalClient(app_id=env('ONESIGNAL_APP_ID'), rest_api_key=env('ONESIGNAL_API_KEY'))
+    client = OneSignalClient(
+        app_id=env('ONESIGNAL_APP_ID'),
+        rest_api_key=env('ONESIGNAL_API_KEY'),
+    )
 
     def send_notification(self, emails, data, message):
         body = self._body(emails, data, message)

--- a/applications/notifications/tests/test_services.py
+++ b/applications/notifications/tests/test_services.py
@@ -1,0 +1,125 @@
+from django.test import TestCase
+import factory
+from faker import Faker
+import mock
+
+from applications.notifications.models import Notification
+from applications.notifications.services import NotificationCreator, NotificationSender
+from applications.users.tests.factories import UserFactory
+from applications.notifications.tests.factories import NotificationFactory
+
+fake = Faker()
+
+
+class TestNotificationCreator(TestCase):
+    def setUp(self):
+        self.user = UserFactory(confirmed=True)
+        params = factory.build(dict, FACTORY_CLASS=NotificationFactory, user=None,)
+        self.title = params['title']
+        self.message = params['message']
+        self.data = {'id': fake.random_number()}
+
+    @mock.patch(
+        'applications.notifications.services.NotificationSender.send_notification',
+        return_value=None
+    )
+    def test_send_notification_successfully_store_notificaiton(self, send_notification):
+        creator = NotificationCreator()
+        creator.create(self.user, self.data, self.title, self.message)
+
+        self.assertEqual(send_notification.call_count, 1)
+
+        last = Notification.objects.filter(user=self.user).last()
+        self.assertEqual(self.user, last.user)
+        self.assertEqual(self.message, last.message)
+
+    @mock.patch(
+        'applications.notifications.services.NotificationSender.send_notification',
+        side_effect=Exception
+    )
+    def test_send_notification_raise_exception_do_not_store_notificaiton(self, send_notification):
+        with self.assertRaises(Exception):
+            creator = NotificationCreator()
+            creator.create(self.user, self.data, self.title, self.message)
+
+            self.assertEqual(send_notification.call_count, 1)
+
+            last = Notification.objects.filter(user=self.user).last()
+            self.assertIsNone(last)
+
+
+class TestNotificationSender(TestCase):
+    def setUp(self):
+        self.emails = [fake.email()] * 5
+        self.data = {'id': fake.random_number()}
+        self.message = fake.text(max_nb_chars=50)
+
+    @mock.patch(
+        'onesignal_sdk.client.Client.send_notification',
+        return_value=None
+    )
+    def test_one_email_param_call_provider_with_valid_generated_data(self, send_notification):
+        sender = NotificationSender()
+        email = self.emails[0]
+        sender.send_notification(email, self.data, self.message)
+
+        self.assertEqual(send_notification.call_count, 1)
+        send_notification.assert_called_once()
+
+        body = {
+            'filters': [
+                {'field': 'tag', 'key': 'email', 'relation': '=', 'value': email},
+            ],
+            'data': self.data,
+            'contents': {'en': self.message},
+        }
+        send_notification.assert_called_with(body)
+
+    @mock.patch(
+        'onesignal_sdk.client.Client.send_notification',
+        return_value=None
+    )
+    def test_one_email_list_param_call_provider_with_valid_generated_data(self, send_notification):
+        sender = NotificationSender()
+        email = self.emails[0]
+        sender.send_notification([email], self.data, self.message)
+
+        self.assertEqual(send_notification.call_count, 1)
+        send_notification.assert_called_once()
+
+        body = {
+            'filters': [
+                {'field': 'tag', 'key': 'email', 'relation': '=', 'value': email},
+            ],
+            'data': self.data,
+            'contents': {'en': self.message},
+        }
+        send_notification.assert_called_with(body)
+
+    @mock.patch(
+        'onesignal_sdk.client.Client.send_notification',
+        return_value=None
+    )
+    def test_many_email_param_call_provider_with_valid_generated_data(self, send_notification):
+        sender = NotificationSender()
+        sender.send_notification(self.emails, self.data, self.message)
+
+        self.assertEqual(send_notification.call_count, 1)
+        send_notification.assert_called_once()
+
+        body = {
+            'filters': [
+                {'field': 'tag', 'key': 'email', 'relation': '=', 'value': self.emails[0]},
+                {'operator': 'OR'},
+                {'field': 'tag', 'key': 'email', 'relation': '=', 'value': self.emails[1]},
+                {'operator': 'OR'},
+                {'field': 'tag', 'key': 'email', 'relation': '=', 'value': self.emails[2]},
+                {'operator': 'OR'},
+                {'field': 'tag', 'key': 'email', 'relation': '=', 'value': self.emails[3]},
+                {'operator': 'OR'},
+                {'field': 'tag', 'key': 'email', 'relation': '=', 'value': self.emails[4]},
+            ],
+            'data': self.data,
+            'contents': {'en': self.message},
+        }
+        send_notification.assert_called_with(body)

--- a/applications/notifications/tests/test_services.py
+++ b/applications/notifications/tests/test_services.py
@@ -37,7 +37,10 @@ class TestNotificationCreator(TestCase):
         'applications.notifications.services.NotificationSender.send_notification',
         side_effect=Exception
     )
-    def test_send_notification_raise_exception_do_not_store_notificaiton(self, send_notification):
+    def test_send_notification_raise_exception_do_not_store_notificaiton(
+        self,
+        send_notification,
+    ):
         with self.assertRaises(Exception):
             creator = NotificationCreator()
             creator.create(self.user, self.data, self.title, self.message)

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,7 @@ flake8==3.8.3
 idna==2.9
 isort==4.2.5
 lazy-object-proxy==1.2.2
+mock==4.0.2
 mccabe==0.6.1
 nose==1.3.7
 oauthlib==3.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,6 +24,7 @@ lazy-object-proxy==1.2.2
 mccabe==0.6.1
 nose==1.3.7
 oauthlib==3.1.0
+onesignal-sdk==2.0.0
 packaging==16.8
 pyparsing==2.1.10
 Pillow==7.2.0


### PR DESCRIPTION
## Notifications service

Trello: [As a user I should receive notifications when a compatible target has been created so we can start getting connected](https://trello.com/c/nuPdXT8n)

#### Description

* Add `NotificationCreator` service to manage the consistency between notifications record and provider
* Integrate OneSignal sdk
* Add `NotificationSender` service to wrap notification provider
* Add services test cases using mocks
 
The `NotificationSender` creates the right input for the OneSignal API [create notifications feature](https://documentation.onesignal.com/reference/create-notification#send-to-users-based-on-filters). So, a right body to send should look like:

```
{
    'filters': [
        {'field': 'tag', 'key': 'email', 'relation': '=', 'value': 'user-1@mail'},
        {'operator': 'OR'},
        {'field': 'tag', 'key': 'email', 'relation': '=', 'value': 'user-2@mail'},
        {'operator': 'OR'},
        {'field': 'tag', 'key': 'email', 'relation': '=', 'value': 'user-3@mail'},
    ],
    'data': {'traget_id': 21},
    'contents': {'en': 'New notification'},
}
```