### PR TITLE
Room creation service

### DIFF
--- a/applications/chats/services.py
+++ b/applications/chats/services.py
@@ -10,23 +10,21 @@ class RoomCreator:
     @transaction.atomic
     def create_from_target_match(self, target, *members):
         if self._exists_equal_room(target.topic, *members):
-            return None
+            return
 
+        self._validate_members(*members)
         room = Room.objects.create(topic=target.topic)
-
-        self._validate_members(room, *members)
-
         room.members.add(*members)
 
     def _exists_equal_room(self, topic, *members):
-        if not len(members) == 2:
-            return False
+        return (
+            len(members) == 2 and
+            Room.objects.filter(topic=topic)
+                .filter(members__id=members[0].id)
+                .filter(members__id=members[1].id)
+                .exists()
+        )
 
-        return Room.objects.filter(
-            members__id__in=[m.id for m in members],
-            topic=topic,
-        ).exists()
-
-    def _validate_members(self, room, *members):
+    def _validate_members(self, *members):
         if len(members) != 2:
             raise ValidationError({'members': _('You must create a room with two members')})

--- a/applications/chats/services.py
+++ b/applications/chats/services.py
@@ -28,8 +28,5 @@ class RoomCreator:
         ).exists()
 
     def _validate_members(self, room, *members):
-        if len(members) < 2:
+        if len(members) != 2:
             raise ValidationError({'members': _('You must create a room with two members')})
-
-        if len(members) > 2:
-            raise ValidationError({'members': _('You can‘t create a room with more than two members')})

--- a/applications/chats/services.py
+++ b/applications/chats/services.py
@@ -1,0 +1,35 @@
+from django.core.exceptions import ValidationError
+from django.db import transaction
+from django.utils.translation import gettext_lazy as _
+
+from .models import Room
+
+
+class RoomCreator(object):
+
+    @transaction.atomic
+    def create_from_target_match(self, target, *members):
+        if self._exists_equal_room(target.topic, *members):
+            return None
+
+        room = Room.objects.create(topic=target.topic)
+
+        self._validate_members(room, *members)
+
+        room.members.add(*members)
+
+    def _exists_equal_room(self, topic, *members):
+        if not len(members) == 2:
+            return False
+
+        return Room.objects.filter(
+            members__id__in=[m.id for m in members],
+            topic=topic,
+        ).exists()
+
+    def _validate_members(self, room, *members):
+        if len(members) < 2:
+            raise ValidationError({'members': _('You must create a room with two members')})
+
+        if len(members) > 2:
+            raise ValidationError({'members': _('You can‘t create a room with more than two members')})

--- a/applications/chats/services.py
+++ b/applications/chats/services.py
@@ -5,7 +5,7 @@ from django.utils.translation import gettext_lazy as _
 from .models import Room
 
 
-class RoomCreator(object):
+class RoomCreator:
 
     @transaction.atomic
     def create_from_target_match(self, target, *members):

--- a/applications/chats/tests/test_services.py
+++ b/applications/chats/tests/test_services.py
@@ -1,0 +1,89 @@
+from django.core.exceptions import ValidationError
+from django.test import TestCase
+
+from applications.chats.services import RoomCreator
+from applications.chats.models import Room
+from applications.chats.tests.factories import RoomFactory
+from applications.targets.tests.factories import TargetFactory, TopicFactory
+from applications.users.tests.factories import UserFactory
+
+
+class TestRoomCreator(TestCase):
+    def setUp(self):
+        self.member_one = UserFactory()
+        self.member_two = UserFactory()
+        topic = TopicFactory()
+        self.target = TargetFactory(owner=self.member_one, topic=topic)
+        self.target = TargetFactory(owner=self.member_two, topic=topic)
+
+    def call_create_from_target_match(self, *members):
+        RoomCreator().create_from_target_match(self.target, *members)
+
+    def test_create_room_with_two_members_successfully(self):
+        self.call_create_from_target_match(self.member_one, self.member_two)
+
+        self.assertEqual(Room.objects.count(), 1)
+        self.assertEqual(
+            Room.objects.filter(members__id=self.member_one.id, topic=self.target.topic).count(),
+            1
+        )
+        self.assertEqual(
+            Room.objects.filter(members__id=self.member_two.id, topic=self.target.topic).count(),
+            1
+        )
+
+    def test_create_room_with_three_members_fail(self):
+        new_user = UserFactory()
+
+        with self.assertRaises(ValidationError) as error:
+            self.call_create_from_target_match(self.member_one, self.member_two, new_user)
+
+        self.assertIsNotNone(error)
+        self.assertDictEqual(
+            error.exception.message_dict,
+            {'members': ['You can‘t create a room with more than two members']}
+        )
+        self.assertEqual(Room.objects.count(), 0)
+        self.assertEqual(
+            Room.objects.filter(members__id=self.member_one.id, topic=self.target.topic).count(),
+            0
+        )
+        self.assertEqual(
+            Room.objects.filter(members__id=self.member_two.id, topic=self.target.topic).count(),
+            0
+        )
+        self.assertEqual(
+            Room.objects.filter(members__id=new_user.id, topic=self.target.topic).count(),
+            0
+        )
+
+    def test_create_room_with_one_members_fail(self):
+        with self.assertRaises(ValidationError) as error:
+            self.call_create_from_target_match(self.member_one)
+
+        self.assertIsNotNone(error)
+        self.assertDictEqual(
+            error.exception.message_dict,
+            {'members': ['You must create a room with two members']}
+        )
+        self.assertEqual(Room.objects.count(), 0)
+        self.assertEqual(
+            Room.objects.filter(members__id=self.member_one.id, topic=self.target.topic).count(),
+            0
+        )
+
+    def test_create_room_replicating_ignore(self):
+        RoomFactory(members=[self.member_one, self.member_two], topic=self.target.topic)
+        self.assertEqual(Room.objects.count(), 1)
+
+        self.call_create_from_target_match(self.member_one, self.member_two)
+
+        self.assertEqual(Room.objects.count(), 1)
+        self.assertEqual(
+            Room.objects.filter(members__id=self.member_one.id, topic=self.target.topic).count(),
+            1
+        )
+        self.assertEqual(
+            Room.objects.filter(members__id=self.member_two.id, topic=self.target.topic).count(),
+            1
+        )

--- a/applications/notifications/services.py
+++ b/applications/notifications/services.py
@@ -36,7 +36,7 @@ class NotificationSender(object):
         return {'field': 'tag', 'key': 'email', 'relation': '=', 'value': email}
 
 
-class NotificationCreator(object):
+class NotificationCreator:
     sender = NotificationSender()
 
     @transaction.atomic

--- a/applications/targets/services.py
+++ b/applications/targets/services.py
@@ -1,5 +1,6 @@
 from django.utils.translation import ugettext_lazy as _
 
+from applications.chats.services import RoomCreator
 from applications.notifications.services import NotificationCreator
 
 
@@ -8,6 +9,7 @@ class TargetMatchingService(object):
     NOTIFICATION_BODY = 'A {} target is near you: {}'
 
     notificator = NotificationCreator()
+    room_creator = RoomCreator()
 
     def process_target(self, target):
         near_targets = target.compatible_query()
@@ -15,6 +17,8 @@ class TargetMatchingService(object):
         for near_target in near_targets:
             self.notificate_match(near_target.owner, target)
             self.notificate_match(target.owner, near_target)
+
+            self.room_creator.create_from_target_match(target, target.owner, near_target.owner)
 
     def notificate_match(self, receiver, target):
         data = {'target_id': target.id}

--- a/applications/targets/tests/test_models.py
+++ b/applications/targets/tests/test_models.py
@@ -21,7 +21,7 @@ class TargetModelTests(TestCase):
     def test_only_one_target_compatible_query_return_empty(self):
         target = factories.TargetFactory()
 
-        self.assertEqual(target.compatible_query().count(), 0)
+        self.assertFalse(target.compatible_query().exists())
 
     def test_same_user_targets_compatible_query_return_empty(self):
         user = UserFactory()
@@ -29,7 +29,7 @@ class TargetModelTests(TestCase):
         targets = factories.TargetFactory.create_batch(size=3, owner=user, topic=topic)
         target = targets[0]
 
-        self.assertEqual(target.compatible_query().count(), 0)
+        self.assertFalse(target.compatible_query().exists())
 
     def test_matching_targets_compatible_query_return_coincidenses(self):
         user = UserFactory()

--- a/applications/targets/tests/test_services.py
+++ b/applications/targets/tests/test_services.py
@@ -6,6 +6,14 @@ from applications.targets.services import TargetMatchingService
 from applications.users.tests.factories import UserFactory
 
 
+@mock.patch(
+    'applications.chats.services.RoomCreator.create_from_target_match',
+    return_value=None
+)
+@mock.patch(
+    'applications.notifications.services.NotificationCreator.create',
+    return_value=None
+)
 class TargetMatchingServiceTest(TestCase):
     def setUp(self):
         self.user = UserFactory()
@@ -16,28 +24,12 @@ class TargetMatchingServiceTest(TestCase):
         matching = TargetMatchingService()
         matching.process_target(self.target)
 
-    @mock.patch(
-        'applications.chats.services.RoomCreator.create_from_target_match',
-        return_value=None
-    )
-    @mock.patch(
-        'applications.notifications.services.NotificationCreator.create',
-        return_value=None
-    )
     def test_targets_do_not_create_notificaitons(self, notificator, room_creator):
         self.call_matching_service()
 
         notificator.assert_not_called()
         room_creator.assert_not_called()
 
-    @mock.patch(
-        'applications.chats.services.RoomCreator.create_from_target_match',
-        return_value=None
-    )
-    @mock.patch(
-        'applications.notifications.services.NotificationCreator.create',
-        return_value=None
-    )
     def test_compatible_targets_create_notificaitons(self, notificator, room_creator):
         matching_target = factories.compatible_in_radius_target(self.topic)
         matching_target2 = factories.compatible_in_radius_target2(self.topic)
@@ -88,14 +80,6 @@ class TargetMatchingServiceTest(TestCase):
         ]
         room_creator.assert_has_calls(calls, any_order=True)
 
-    @mock.patch(
-        'applications.chats.services.RoomCreator.create_from_target_match',
-        return_value=None
-    )
-    @mock.patch(
-        'applications.notifications.services.NotificationCreator.create',
-        return_value=None
-    )
     def test_no_compatible_targets_do_not_create_notificaitons(self, notificator, room_creator):
         other_topic = factories.TopicFactory()
         factories.incompatible_in_radius_target(other_topic)

--- a/applications/targets/tests/test_target_create.py
+++ b/applications/targets/tests/test_target_create.py
@@ -178,6 +178,6 @@ class TargetCreateTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(self.user.target_set.count(), 1)
 
-        self.assertEqual(self.user.notification_set.count(), 0)
+        self.assertFalse(self.user.notification_set.all().exists())
 
         self.assertEqual(notificator.call_count, 0)


### PR DESCRIPTION
## Room creation service

Trello: [As a user I should be able to see all my conversations](https://trello.com/c/5mWQqc84)

#### Description

* Add service to create rooms
* Add integrity restrictions:
  * A room is only between two users
  * A room is unique according to the members and the topic. So, if the same users match by a newly added target while the topic is the same that the previous match, a new room won't be created.
* Call new service from `TargetMatchingService`
* Update `TargetMatchingService` test cases
